### PR TITLE
Made it possible to save mangas

### DIFF
--- a/src/main/java/com/example/c11_examensarbete/config/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/c11_examensarbete/config/CustomAuthenticationSuccessHandler.java
@@ -40,6 +40,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
         String email = oAuth2User.getAttribute("email");
         String name = oAuth2User.getAttribute("name");
         String picture = oAuth2User.getAttribute("avatar_url");
+        int oAuthId = oAuth2User.getAttribute("id");
 
         // Check if user exists in the database, and save/update accordingly
         userRepository.findByEmail(email).ifPresentOrElse(
@@ -48,6 +49,8 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
                     user.setUsername(name);
                     user.setProfilePictureUrl(picture);
                     user.setAccessToken(accessToken);
+                    user.setOauthProvider(clientRegistrationId);
+                    user.setOauthProviderId(String.valueOf(oAuthId));
                     user.setUpdatedAt(Instant.now());
                     if(user.getRole().isEmpty()) {
                         user.setRole("USER");
@@ -60,6 +63,8 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
                     User newUser = new User();
                     newUser.setEmail(email);
                     newUser.setUsername(name);
+                    newUser.setOauthProvider(clientRegistrationId);
+                    newUser.setOauthProviderId(String.valueOf(oAuthId));
                     newUser.setProfilePictureUrl(picture);
                     newUser.setAccessToken(accessToken);
                     newUser.setCreatedAt(Instant.now());

--- a/src/main/java/com/example/c11_examensarbete/controllers/SavedMangaController.java
+++ b/src/main/java/com/example/c11_examensarbete/controllers/SavedMangaController.java
@@ -2,33 +2,48 @@ package com.example.c11_examensarbete.controllers;
 
 
 import com.example.c11_examensarbete.dtos.CommentDto;
+import com.example.c11_examensarbete.dtos.MangaDto;
 import com.example.c11_examensarbete.dtos.SavedMangaDto;
+import com.example.c11_examensarbete.services.MangaService;
 import com.example.c11_examensarbete.services.SavedMangaService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1")
 public class SavedMangaController {
 
+    private final MangaService mangaService;
     SavedMangaService savedMangaService;
 
-    public SavedMangaController(SavedMangaService savedMangaService) {
+    public SavedMangaController(SavedMangaService savedMangaService, MangaService mangaService) {
         this.savedMangaService = savedMangaService;
+        this.mangaService = mangaService;
     }
 
     //TODO: Works in bruno but no exeption handling
     @GetMapping("/user/{userid}/mangas")
-    public List<SavedMangaDto> getUsersSavedMangas(@PathVariable int userid) {
-        List<SavedMangaDto> manga = savedMangaService.getUsersSavedMangas(userid);
-        return manga;
+    public List<MangaDto> getUsersSavedMangas(@PathVariable int userid) {
+        // Fetch the SavedMangaDto for the user
+        List<SavedMangaDto> savedMangas = savedMangaService.getUsersSavedMangas(userid);
+
+        // Collect all the manga IDs from the SavedMangaDto list
+        List<Integer> mangaIds = savedMangas.stream()
+                .map(savedManga -> savedManga.mangaid())
+                .collect(Collectors.toList());
+
+        // Fetch all MangaDto objects for the collected manga IDs
+        List<MangaDto> mangaDtos = mangaService.getMangaByIds(mangaIds);
+
+        return mangaDtos;
     }
 
     //TODO: Works in bruno but no exeption handling
-    @PostMapping("/user/{userid}/manga")
+    @PostMapping("/user/manga")
     public ResponseEntity<Void> addSavedManga(@RequestBody SavedMangaDto savedMangaDto) {
         int id = savedMangaService.saveManga(savedMangaDto);
         return ResponseEntity.created(URI.create("/reviews/comments/" + id)).build();

--- a/src/main/java/com/example/c11_examensarbete/controllers/UserController.java
+++ b/src/main/java/com/example/c11_examensarbete/controllers/UserController.java
@@ -29,10 +29,18 @@ public class UserController {
     }
 
 
+
+
     //TODO: Works in bruno but no exeption handling
     @GetMapping("/users")
     public List<UserDto> getAllUsers() {
         List<UserDto> user = userService.getAllUsers();
+        return user;
+    }
+
+    @GetMapping("/user/data/{oauthId}")
+    public UserDto getUsersByOauthId(@PathVariable String oauthId) {
+       UserDto user = userService.getUsersByOauthId(oauthId);
         return user;
     }
 

--- a/src/main/java/com/example/c11_examensarbete/dtos/SavedMangaDto.java
+++ b/src/main/java/com/example/c11_examensarbete/dtos/SavedMangaDto.java
@@ -3,13 +3,20 @@ package com.example.c11_examensarbete.dtos;
 import com.example.c11_examensarbete.entities.SavedManga;
 
 public record SavedMangaDto(
-        int manga_id,
-        int user_id
+        int mangaid,
+        int userid,
+        Float score,
+        Integer chaptersRead,
+        String status
 ) {
-    public static SavedMangaDto fromSavedManga(SavedManga savedManga){
+    public static SavedMangaDto fromSavedManga(SavedManga savedManga) {
         return new SavedMangaDto(
                 savedManga.getManga().getId(),
-                savedManga.getUser().getId()
+                savedManga.getUser().getId(),
+                savedManga.getPersonalRating(),
+                savedManga.getCurrentChapter(),
+                savedManga.getStatus()
         );
     }
 }
+

--- a/src/main/java/com/example/c11_examensarbete/dtos/UserDto.java
+++ b/src/main/java/com/example/c11_examensarbete/dtos/UserDto.java
@@ -2,16 +2,24 @@ package com.example.c11_examensarbete.dtos;
 
 import com.example.c11_examensarbete.entities.User;
 
+import java.time.Instant;
+
 public record UserDto(
+        int id,
         String username,
         String email,
-        String role
-) {
+        String role,
+        String profilePictureUrl,
+        Instant createdAt) {
     public static UserDto fromUser(User user) {
         return new UserDto(
+                user.getId(),
                 user.getUsername(),
                 user.getEmail(),
-                user.getRole()
+                user.getRole(),
+                user.getProfilePictureUrl(),
+                user.getCreatedAt()
+
         );
     }
 }

--- a/src/main/java/com/example/c11_examensarbete/entities/SavedManga.java
+++ b/src/main/java/com/example/c11_examensarbete/entities/SavedManga.java
@@ -1,9 +1,12 @@
 package com.example.c11_examensarbete.entities;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
+import java.time.Instant;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -12,6 +15,7 @@ import java.util.Set;
 @Entity
 @Table(name = "saved_manga", schema = "mydatabase")
 public class SavedManga {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
@@ -32,4 +36,37 @@ public class SavedManga {
             inverseJoinColumns = @JoinColumn(name = "list_id")
     )
     private Set<List> lists = new LinkedHashSet<>();
+
+    @Column(name = "personal_rating")
+    private Float personalRating;
+
+    @ColumnDefault("0")
+    @Column(name = "current_chapter")
+    private Integer currentChapter;
+
+    @Size(max = 50)
+    @ColumnDefault("'not started'")
+    @Column(name = "status", length = 50)
+    private String status;
+
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    // PrePersist and PreUpdate lifecycle callbacks to set timestamps
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
 }

--- a/src/main/java/com/example/c11_examensarbete/repositories/UserRepository.java
+++ b/src/main/java/com/example/c11_examensarbete/repositories/UserRepository.java
@@ -4,9 +4,12 @@ import aj.org.objectweb.asm.commons.Remapper;
 import com.example.c11_examensarbete.entities.User;
 import org.springframework.data.repository.ListCrudRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends ListCrudRepository<User, Integer> {
     Optional<User> findByEmail(String email);
     User findByUsername(String username);
+
+    User findByOauthProviderId(String oauthId);
 }

--- a/src/main/java/com/example/c11_examensarbete/services/MangaService.java
+++ b/src/main/java/com/example/c11_examensarbete/services/MangaService.java
@@ -4,6 +4,7 @@ import com.example.c11_examensarbete.dtos.AuthorDto;
 import com.example.c11_examensarbete.dtos.GenreDto;
 import com.example.c11_examensarbete.dtos.ImageDto;
 import com.example.c11_examensarbete.dtos.MangaDto;
+import com.example.c11_examensarbete.entities.Manga;
 import com.example.c11_examensarbete.repositories.ImageRepository;
 import com.example.c11_examensarbete.repositories.MangaRepository;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class MangaService {
@@ -182,5 +184,12 @@ public class MangaService {
         Pageable pageable = PageRequest.of(page, size);
         return mangaRepository.findAllByTitleContaining(search, pageable)
                 .map(MangaDto::fromManga);
+    }
+
+    public List<MangaDto> getMangaByIds(List<Integer> mangaIds) {
+        List<Manga> mangas = mangaRepository.findAllById(mangaIds);
+        return mangas.stream()
+                .map(MangaDto::fromManga) // Assuming MangaDto can be created from Manga entity
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/c11_examensarbete/services/SavedMangaService.java
+++ b/src/main/java/com/example/c11_examensarbete/services/SavedMangaService.java
@@ -33,12 +33,16 @@ public class SavedMangaService {
     }
 
     public int saveManga(SavedMangaDto savedMangaDto) {
-        System.out.println(savedMangaDto.manga_id());
+        System.out.println(savedMangaDto.mangaid());
         SavedManga savedManga = new SavedManga();
-        savedManga.setManga(mangaRepository.findById(savedMangaDto.manga_id())
-                .orElseThrow(() -> new NoSuchElementException("Manga not found with id: " + savedMangaDto.manga_id())));
-        savedManga.setUser(userRepository.findById(savedMangaDto.user_id())
-                .orElseThrow(() -> new NoSuchElementException("User not found with id: " + savedMangaDto.user_id())));
+        savedManga.setManga(mangaRepository.findById(savedMangaDto.mangaid())
+                .orElseThrow(() -> new NoSuchElementException("Manga not found with id: " + savedMangaDto.mangaid())));
+        savedManga.setUser(userRepository.findById(savedMangaDto.userid())
+                .orElseThrow(() -> new NoSuchElementException("User not found with id: " + savedMangaDto.userid())));
+
+        savedManga.setStatus(savedMangaDto.status());
+        savedManga.setPersonalRating(savedMangaDto.score());
+        savedManga.setCurrentChapter(savedMangaDto.chaptersRead());
         savedMangaRepository.save(savedManga);
         return savedManga.getId();
     }

--- a/src/main/java/com/example/c11_examensarbete/services/UserService.java
+++ b/src/main/java/com/example/c11_examensarbete/services/UserService.java
@@ -25,6 +25,11 @@ public class UserService {
                 .toList();
     }
 
+    public UserDto getUsersByOauthId(String oauthId){
+        User user = userRepository.findByOauthProviderId(oauthId);
+        return UserDto.fromUser(user);
+    }
+
     public List<UserDto> getUsersById(int id){
         return userRepository.findById(id).stream()
                 .map(UserDto::fromUser)
@@ -58,4 +63,6 @@ public class UserService {
     public int updateUser(User user){
         return userRepository.save(user).getId();
     }
+
+
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -84,6 +84,11 @@ CREATE TABLE IF NOT EXISTS saved_manga
     id       INT PRIMARY KEY AUTO_INCREMENT,
     user_id  INT,
     manga_id INT,
+    personal_rating FLOAT DEFAULT NULL,
+    current_chapter INT DEFAULT 0,
+    status VARCHAR(50) DEFAULT 'not started',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users (id),
     FOREIGN KEY (manga_id) REFERENCES manga (id),
     UNIQUE (manga_id, user_id)


### PR DESCRIPTION

This PR introduces the ability for users to save their manga progress, including personal rating, current chapter, and status. Additionally, the saved manga is displayed on the user's profile page, allowing users to manage and track their manga library.

### **Changes Made:**

1. **`SavedMangaController`**:
   - Added an endpoint to fetch saved mangas for a specific user and return detailed `MangaDto` objects by fetching manga data based on saved manga IDs.

2. **`SavedMangaDto`**:
   - Modified `SavedMangaDto` to include additional fields such as `score`, `chaptersRead`, and `status` for more detailed saved manga data.
   - Adjusted the `fromSavedManga` method to map these additional fields from the `SavedManga` entity.

3. **`SavedManga` Entity**:
   - Updated the `SavedManga` entity to store the user's manga progress: personal rating, current chapter, and status.
   - Implemented JPA lifecycle hooks to auto-set `createdAt` and `updatedAt` timestamps when creating or updating the entity.

4. **`SavedMangaService`**:
   - Modified the service layer to handle saving manga progress with all the new fields (`score`, `chaptersRead`, `status`).
   - Implemented logic to fetch saved manga details for a specific user and return the appropriate `SavedMangaDto` objects.

5. **Database Schema**:
   - Updated the `saved_manga` table in the database schema to include the new columns for `personal_rating`, `current_chapter`, `status`, and timestamps (`created_at`, `updated_at`).
   - Ensured that these columns are populated correctly when saving new manga entries.

6. **`UserController`**:
   - Added a method to fetch users based on their OAuth ID to provide a unified user view.

7. **`MangaService`**:
   - Added a method `getMangaByIds` to retrieve `MangaDto` objects by a list of manga IDs, allowing efficient fetching of manga details for multiple saved mangas.

8. **User Data Handling**:
   - Adjusted the `UserDto` and `UserService` to support fetching user details, including the new fields like `profilePictureUrl` and `createdAt`.

### **Feature Highlights**:
- **Manga Saving**: Users can now save their progress for manga, including rating, chapter, and status (e.g., "Reading", "Completed").
- **User Library**: Users can view all their saved manga in their library, with the option to track progress and ratings.
- **Database and Entity Updates**: The schema and entities were updated to reflect these changes and ensure the integrity of the saved data.

### **To-Do (Still in Progress)**:
- **Styling**: The frontend for displaying the manga library and saving manga progress is functional, but still needs additional styling and UI improvements.

### **Testing**:
- Manual tests were conducted to ensure that saved manga entries are correctly stored in the database with all the new attributes.
- The user profile page correctly displays the saved mangas and their associated details (rating, chapter, and status).

### **Screenshots/Visuals**:
*(Add any screenshots or GIFs here if available)*

---

